### PR TITLE
fix: update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,6 @@
   "publishConfig": {
     "registry": "https://registry.npmjs.org/"
   },
-  "type": "module",
   "author": "mdh",
   "license": "MIT",
   "description": "Configurable 3d cube loading spinner built with and for ReactJS",


### PR DESCRIPTION
Fix this error

```bash
.releaserc.js is treated as an ES module file as it is a .js file whose nearest parent package.json contains "type": "module" which declares all .js files in that package scope as ES modules.
Instead either rename .releaserc.js to end in .cjs, change the requiring code to use dynamic import() which is available in all CommonJS modules, or change "type": "module" to "type": "commonjs" in /home/runner/work/react-cube-loading-spinner/react-cube-loading-spinner/package.json to treat all .js files as CommonJS (using .mjs for all ES modules instead).
```